### PR TITLE
Initial preparation for alternative front-ends

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,12 @@
+# Per-instance database files
+# Anchored at top-level:
+/*.lmdb/
+/*.index
+
+# Python virtual environment
+# Anchored at top-level:
+/env/
+
+# Build results
+# Anywhere:
+__pycache__/

--- a/query-index.py
+++ b/query-index.py
@@ -65,60 +65,82 @@ def merge_faiss_results_1d_dict(D, I, lookup):
             results[str(fix_idx[0])] = [fix_idx[1], D[i]]
     return results
 
-#device = "cuda" if torch.cuda.is_available() else "cpu"
-device = "cpu"
-model, transform = clip.load("ViT-B/32", device=device, jit=False)
-
-model.eval()
-
-database.open_db()
-config.open_db()
-
-index = faiss.read_index("images.index")
-index.nprobe = config.get_setting_int("probe", 64)
-
-faces_index = faiss.read_index("faces.index")
-faces_index.nprobe = config.get_setting_int("probe", 64)
 
 for orientation in ExifTags.TAGS.keys():
     if ExifTags.TAGS[orientation] == 'Orientation':
         break
 
-in_text = ""
-texts = None
-features = None
-show_faces = config.get_setting_bool("show_faces", False)
-show_prefix = config.get_setting_bool("show_prefix", True)
-face_threshold = config.get_setting_float("face_threshold", 0.60)
-clip_threshold = config.get_setting_float("clip_threshold", 0.19)
-k = config.get_setting_int("k", 50)
-offset = 0
-last_j = 0
-search_mode = -1
-max_res = None
-if config.get_setting_bool("max_res_set", False):
-    max_res = (config.get_setting_int("max_res_x", 1280), config.get_setting_int("max_res_y", 720))
-align_window = config.get_setting_bool("align_window", False)
-results = None
-skip_same = config.get_setting_bool("skip_same", True)
-growth_limit = config.get_setting_int("growth_limit", 2**16)
-last_vector = None
-face_features = None
-file_filter = None
-file_filter_mode = True # Inverted?
-target_tag = None
-skip_perfect = config.get_setting_bool('skip_perfect', False)
-print("For help, type: h")
-try:
-    while in_text != 'q':
-        # Handle commands
-        prefix = "[h,q,l,i,if,t,T,t+,t-,t?,ff,s,sp,r,a,n,ft,ct,p,k,gl] "
-        if not show_prefix:
-            prefix = ""
-        in_text = input(prefix + ">>> ").strip()
-        if in_text == 'q':
-            break
-        elif in_text == 'h':
+
+class Search:
+
+    def __init__(self, device=None):
+        if device == None:
+            #device = "cuda" if torch.cuda.is_available() else "cpu"
+            device = "cpu"
+        self.device = device
+
+        self.model, transform = clip.load("ViT-B/32", device=device, jit=False)
+
+        self.model.eval()
+
+        database.open_db()
+        config.open_db()
+
+        self.index = faiss.read_index("images.index")
+        self.index.nprobe = config.get_setting_int("probe", 64)
+
+        self.faces_index = faiss.read_index("faces.index")
+        self.faces_index.nprobe = config.get_setting_int("probe", 64)
+
+        self.in_text = ""
+        self.texts = None
+        self.features = None
+        self.show_faces = config.get_setting_bool("show_faces", False)
+        self.show_prefix = config.get_setting_bool("show_prefix", True)
+        self.face_threshold = config.get_setting_float("face_threshold", 0.60)
+        self.clip_threshold = config.get_setting_float("clip_threshold", 0.19)
+        self.k = config.get_setting_int("k", 50)
+        self.offset = 0
+        self.last_j = 0
+        self.search_mode = -1
+        self.max_res = None
+        if config.get_setting_bool("max_res_set", False):
+            self.max_res = (config.get_setting_int("max_res_x", 1280), config.get_setting_int("max_res_y", 720))
+        self.align_window = config.get_setting_bool("align_window", False)
+        self.results = None
+        self.skip_same = config.get_setting_bool("skip_same", True)
+        self.growth_limit = config.get_setting_int("growth_limit", 2**16)
+        self.last_vector = None
+        self.face_features = None
+        self.file_filter = None
+        self.file_filter_mode = True # Inverted?
+        self.target_tag = None
+        self.skip_perfect = config.get_setting_bool('skip_perfect', False)
+
+    def run_cli(self):  # (CLI: command-line interface)
+        print("For help, type: h")
+        try:
+            while self.in_text != 'q':
+                # Handle commands
+                prefix = "[h,q,l,i,if,t,T,t+,t-,t?,ff,s,sp,r,a,n,ft,ct,p,k,gl] "
+                if not self.show_prefix:
+                    prefix = ""
+                self.in_text = input(prefix + ">>> ").strip()
+                iteration_done = self.do_command()
+                if iteration_done:
+                    continue
+
+                self.do_search()
+                self.do_display()
+        except EOFError:
+            print("Goodbye.")
+        except KeyboardInterrupt:
+            print("Interrupted.")
+
+    def do_command(self):
+        if self.in_text == 'q':
+            return True
+        elif self.in_text == 'h':
             print("Enter a search query and you will receive a list of best matching\n"
                   "images. The first number is the difference score, the second the\n"
                   "image ID followed by the filename.\n"
@@ -161,148 +183,148 @@ try:
                   "gl NUM\t\tSet maximum internal search result number (default: 65536)\n"
                   "h\t\tShow this help"
                  )
-            continue
-        elif in_text.startswith('gl '):
+            return True
+        elif self.in_text.startswith('gl '):
             try:
-                limit = int(in_text[3:])
+                limit = int(self.in_text[3:])
                 if limit < 0:
                     raise Exception
-                growth_limit = limit
-                config.set_setting_float("growth_limit", growth_limit)
+                self.growth_limit = limit
+                config.set_setting_float("growth_limit", self.growth_limit)
                 print(f"Set search growth limit to {growth_limit}.")
             except:
                 print("Invalid search growth limit.")
-            continue
-        elif in_text.startswith('ct '):
+            return True
+        elif self.in_text.startswith('ct '):
             try:
-                threshold = float(in_text[3:])
+                threshold = float(self.in_text[3:])
                 if threshold < 0.0 or threshold > 1.0:
                     raise Exception
-                clip_threshold = threshold
-                config.set_setting_float("clip_threshold", clip_threshold)
+                self.clip_threshold = threshold
+                config.set_setting_float("clip_threshold", self.clip_threshold)
                 print(f"Set CLIP similarity threshold to {clip_threshold}.")
             except:
                 print("Invalid CLIP threshold value.")
-            continue
-        elif in_text.startswith('ft '):
+            return True
+        elif self.in_text.startswith('ft '):
             try:
-                threshold = float(in_text[3:])
+                threshold = float(self.in_text[3:])
                 if threshold < 0.0 or threshold > 1.0:
                     raise Exception
-                face_threshold = threshold
-                config.set_setting_float("face_threshold", face_threshold)
+                self.face_threshold = threshold
+                config.set_setting_float("face_threshold", self.face_threshold)
                 print(f"Set face similarity threshold to {face_threshold}.")
             except:
                 print("Invalid face threshold value.")
-            continue
-        elif in_text.startswith('p '):
+            return True
+        elif self.in_text.startswith('p '):
             try:
-                probe = int(in_text[2:])
+                probe = int(self.in_text[2:])
                 if probe <= 0 or probe > 100:
                     raise Exception
-                index.nprobe = probe
-                faces_index.nprobe = probe
+                self.index.nprobe = probe
+                self.faces_index.nprobe = probe
                 config.set_setting_int("probe", probe)
                 print(f"Set to probe {probe} subsets.")
             except:
                 print("Invalid probe value.")
-            continue
-        elif in_text == 'fs':
-            skip_perfect = not skip_perfect
-            config.set_setting_bool("skip_perfect", skip_perfect)
-            if skip_perfect:
+            return True
+        elif self.in_text == 'fs':
+            self.skip_perfect = not self.skip_perfect
+            config.set_setting_bool("skip_perfect", self.skip_perfect)
+            if self.skip_perfect:
                 print("Skipping perfect matches.")
             else:
                 print("Not skipping perfect matches images.")
-            continue
-        elif in_text == 'k':
-            skip_same = not skip_same
-            config.set_setting_bool("skip_same", skip_same)
-            if skip_same:
+            return True
+        elif self.in_text == 'k':
+            self.skip_same = not self.skip_same
+            config.set_setting_bool("skip_same", self.skip_same)
+            if self.skip_same:
                 print("Skipping images with the same CLIP features as previous.")
             else:
                 print("Not skipping images.")
-            continue
-        elif in_text == 's':
-            show_faces = not show_faces
-            config.set_setting_bool("show_faces", show_faces)
-            if show_faces:
+            return True
+        elif self.in_text == 's':
+            self.show_faces = not self.show_faces
+            config.set_setting_bool("show_faces", self.show_faces)
+            if self.show_faces:
                 print("Showing face information.")
             else:
                 print("Not showing face information.")
-            continue
-        elif in_text == 'sp':
-            show_prefix = not show_prefix
-            config.set_setting_bool("show_prefix", show_prefix)
-            if show_prefix:
+            return True
+        elif self.in_text == 'sp':
+            self.show_prefix = not self.show_prefix
+            config.set_setting_bool("show_prefix", self.show_prefix)
+            if self.show_prefix:
                 print("Showing prompt prefix.")
             else:
                 print("Not prompt prefix.")
-            continue
-        elif in_text == 'ff!':
-            file_filter_mode = not file_filter_mode
-            if file_filter_mode:
+            return True
+        elif self.in_text == 'ff!':
+            self.file_filter_mode = not self.file_filter_mode
+            if self.file_filter_mode:
                 print("Showing files with matching filenames.")
             else:
                 print("Skipping files with matching filenames.")
-            continue
-        elif in_text == 'ff':
-            file_filter = None
+            return True
+        elif self.in_text == 'ff':
+            self.file_filter = None
             print("Disabled filename filter.")
-            continue
-        elif in_text == 'a':
-            align_window = not align_window
-            config.set_setting_bool("align_window", align_window)
-            if align_window:
+            return True
+        elif self.in_text == 'a':
+            self.align_window = not self.align_window
+            config.set_setting_bool("align_window", self.align_window)
+            if self.align_window:
                 print("Aligning window position.")
             else:
                 print("Not aligning window position.")
-            continue
-        elif in_text.startswith('ff '):
-            file_filter = re.compile(in_text[3:])
+            return True
+        elif self.in_text.startswith('ff '):
+            self.file_filter = re.compile(self.in_text[3:])
             print("Set filename filter regular expression.")
-            continue
-        elif in_text.startswith('r '):
-            res = in_text[2:]
+            return True
+        elif self.in_text.startswith('r '):
+            res = self.in_text[2:]
             try:
                 x, y = res.split('x')
                 x = int(x)
                 y = int(y)
                 if x > 0 and y > 0:
-                    max_res = (x, y)
+                    self.max_res = (x, y)
                     config.set_setting_bool("max_res_set", True)
                     config.set_setting_int("max_res_x", x)
                     config.set_setting_int("max_res_y", y)
                     print(f"Set maximum resolution to {x}x{y}.")
-                    continue
+                    return True
             except:
                 pass
-            max_res = None
+            self.max_res = None
             config.set_setting_bool("max_res_set", False)
             print("Unset maximum resolution.")
-            continue
-        elif in_text.startswith('n '):
+            return True
+        elif self.in_text.startswith('n '):
             try:
-                k = int(in_text[2:])
-                if k < 1:
-                    k = 50
+                self.k = int(self.in_text[2:])
+                if self.k < 1:
+                    self.k = 50
                     print("Reset number of results to 50.")
-                    continue
-                print(f"Showing {k} results.")
+                    return True
+                print(f"Showing {self.k} results.")
             except:
                 print("Error")
-            continue
-        elif in_text == 'tl':
+            return True
+        elif self.in_text == 'tl':
             print("Existing tags:")
             print("#Faces\tTag")
             tags = sorted(config.list_tags(), key=lambda x: x[1])
             for tag in tags:
                 num, name = tag
                 print(f"{num}\t{name}")
-            continue
-        elif in_text.startswith('t+ '):
+            return True
+        elif self.in_text.startswith('t+ '):
             try:
-                parts = in_text[3:].split(" ")
+                parts = self.in_text[3:].split(" ")
                 tag = parts[0]
                 image_id = int(parts[1])
                 face_id = int(parts[2])
@@ -311,10 +333,10 @@ try:
                 print(f"Added face {face_id} from image {image_id} to tag {tag}.")
             except:
                 print("Adding to tag failed.")
-            continue
-        elif in_text.startswith('t- '):
+            return True
+        elif self.in_text.startswith('t- '):
             try:
-                parts = in_text[3:].split(" ")
+                parts = self.in_text[3:].split(" ")
                 tag = parts[0]
                 image_id = int(parts[1])
                 face_id = int(parts[2])
@@ -323,31 +345,31 @@ try:
                 print(f"Removed face {face_id} from image {image_id} from tag {tag}.")
             except:
                 print("Removing from tag failed.")
-            continue
-        elif in_text.startswith('t? '):
+            return True
+        elif self.in_text.startswith('t? '):
             try:
-                tag = in_text[3:]
-                results = config.get_tag_contents(tag)
-                if results is None or tag == "" or len(results) < 1:
+                tag = self.in_text[3:]
+                self.results = config.get_tag_contents(tag)
+                if self.results is None or tag == "" or len(self.results) < 1:
                     print("Not found.")
-                    continue
-                offset = -1
-                last_j = 0
+                    return True
+                self.offset = -1
+                self.last_j = 0
                 print(f"Showing tag {tag}:")
                 print(f"Image\tFace")
-                for result, score in results:
+                for result, score in self.results:
                     print(f"{result[0]}\t{result[1]}")
-                search_mode = -2
-                target_tag = tag
-                last_vector = None
+                self.search_mode = -2
+                self.target_tag = tag
+                self.last_vector = None
             except:
                 print("Error")
-                continue
-        elif in_text.startswith('l '):
+                return True
+        elif self.in_text.startswith('l '):
             try:
-                image_id = int(in_text[2:])
-                offset = -1
-                last_j = 0
+                image_id = int(self.in_text[2:])
+                self.offset = -1
+                self.last_j = 0
                 try:
                     filename = database.get_fix_idx_filename(image_id)
                     features = database.get_fix_idx_vector(image_id)
@@ -355,165 +377,165 @@ try:
                     print(f"Showing {filename}:")
                     print(f"Image\tFace\tTag\tBounding box")
                     for i, annotation in enumerate(annotations):
-                        tag = config.get_face_tag(annotation, face_threshold)
+                        tag = config.get_face_tag(annotation, self.face_threshold)
                         print(f"{image_id}\t{i}\t{tag}\t{annotation['bbox']}")
                 except:
                     print("Not found.")
-                    continue
-                results = [(image_id, 1.0)] * k
-                search_mode = -2
-                target_tag = None
-                last_vector = None
+                    return True
+                self.results = [(image_id, 1.0)] * self.k
+                self.search_mode = -2
+                self.target_tag = None
+                self.last_vector = None
             except:
                 print("Error")
-                continue
-        elif in_text.startswith('t ') or in_text.startswith('T '):
+                return True
+        elif self.in_text.startswith('t ') or self.in_text.startswith('T '):
             try:
-                search_mode = 1
-                last_vector = None
-                parts = in_text[2:].split(" ", 2)
+                self.search_mode = 1
+                self.last_vector = None
+                parts = self.in_text[2:].split(" ", 2)
                 tag = parts[0]
-                target_tag = tag
-                offset = -1
-                last_j = 0
+                self.target_tag = tag
+                self.offset = -1
+                self.last_j = 0
 
-                features = config.get_tag_embeddings(tag)
-                if in_text.startswith('T '):
-                    average = features.mean(0, keepdims=True)
+                self.features = config.get_tag_embeddings(tag)
+                if self.in_text.startswith('T '):
+                    average = self.features.mean(0, keepdims=True)
                     average = normalize(average)
-                    features = np.append(features, average, axis=0)
-                if features is None:
+                    self.features = np.append(self.features, average, axis=0)
+                if self.features is None:
                     print("Not found.")
-                    search_mode = -1
-                    last_vector = None
-                    continue
+                    self.search_mode = -1
+                    self.last_vector = None
+                    return True
                 if len(parts) > 1:
-                    face_features = features
-                    search_mode = 2
-                    texts = clip.tokenize([parts[1]]).to(device)
-                    features = normalize(model.encode_text(texts).detach().cpu().numpy().astype('float32'))
+                    self.face_features = self.features
+                    self.search_mode = 2
+                    self.texts = clip.tokenize([parts[1]]).to(self.device)
+                    self.features = normalize(self.model.encode_text(self.texts).detach().cpu().numpy().astype('float32'))
                 print(f"Similar faces to {tag}:")
             except:
                 print("Error")
-                continue
-        elif in_text.startswith('if '):
+                return True
+        elif self.in_text.startswith('if '):
             try:
-                search_mode = 1
-                target_tag = None
-                last_vector = None
-                parts = in_text[3:].split(" ", 3)
+                self.search_mode = 1
+                self.target_tag = None
+                self.last_vector = None
+                parts = self.in_text[3:].split(" ", 3)
                 image_id = int(parts[0])
                 face_id = int(parts[1])
-                offset = -1
-                last_j = 0
+                self.offset = -1
+                self.last_j = 0
 
                 filename = database.get_fix_idx_filename(image_id)
                 annotations = database.get_faces(database.i2b(image_id))
-                features = annotations[face_id]['embedding']
+                self.features = annotations[face_id]['embedding']
                 if len(parts) > 2:
-                    face_features = features
-                    search_mode = 2
-                    texts = clip.tokenize([parts[2]]).to(device)
-                    features = normalize(model.encode_text(texts).detach().cpu().numpy().astype('float32'))
+                    self.face_features = self.features
+                    self.search_mode = 2
+                    self.texts = clip.tokenize([parts[2]]).to(self.device)
+                    self.features = normalize(self.model.encode_text(self.texts).detach().cpu().numpy().astype('float32'))
                 print(f"Similar faces to {face_id} in {image_id}:")
             except:
                 print("Not found.")
-                search_mode = -1
-                last_vector = None
-                continue
-        elif in_text.startswith('i '):
+                self.search_mode = -1
+                self.last_vector = None
+                return True
+        elif self.in_text.startswith('i '):
             try:
-                image_id = int(in_text[2:])
-                offset = -1
-                last_j = 0
+                image_id = int(self.in_text[2:])
+                self.offset = -1
+                self.last_j = 0
                 filename = database.get_fix_idx_filename(image_id)
-                features = database.get_fix_idx_vector(image_id)
+                self.features = database.get_fix_idx_vector(image_id)
                 print(f"Similar to {filename}:")
             except:
                 print("Not found.")
-                continue
-            search_mode = 0
-            target_tag = None
-            last_vector = None
-        elif in_text == '':
-            offset = last_j
-            if features is None and search_mode > 0:
-                continue
+                return True
+            self.search_mode = 0
+            self.target_tag = None
+            self.last_vector = None
+        elif self.in_text == '':
+            self.offset = self.last_j
+            if self.features is None and self.search_mode > 0:
+                return True
         else:
-            offset = -1
-            last_j = 0
-            texts = clip.tokenize([in_text]).to(device)
-            features = normalize(model.encode_text(texts).detach().cpu().numpy().astype('float32'))
-            search_mode = 0
-            target_tag = None
-            last_vector = None
+            self.offset = -1
+            self.last_j = 0
+            self.texts = clip.tokenize([self.in_text]).to(self.device)
+            self.features = normalize(self.model.encode_text(self.texts).detach().cpu().numpy().astype('float32'))
+            self.search_mode = 0
+            self.target_tag = None
+            self.last_vector = None
 
-        # Do search
-        if search_mode == 0:
+    def do_search(self):
+        if self.search_mode == 0:
             # Search CLIP features
             search_start = time.perf_counter()
             last_results_num = -1
             I = [[]]
             extra = 0
             valid_results = 0
-            while valid_results < k + offset + 2 and len(I[0]) > last_results_num:
+            while valid_results < self.k + self.offset + 2 and len(I[0]) > last_results_num:
                 last_results_num = len(I[0])
-                D, I = index.search(features, k + offset + 2 + extra)
-                results = merge_faiss_results(D, I, database.get_idx)
-                if file_filter is None:
+                D, I = self.index.search(self.features, self.k + self.offset + 2 + extra)
+                self.results = merge_faiss_results(D, I, database.get_idx)
+                if self.file_filter is None:
                     break
                 if extra == 0:
                     extra = 64
                 else:
                     extra *= 2
-                if extra > growth_limit:
+                if extra > self.growth_limit:
                     break
                 valid_results = 0
-                for result in results:
+                for result in self.results:
                     tfn = ""
                     if type(result[0]) is tuple:
                         tfn = database.get_fix_idx_filename(result[0][0])
                     else:
                         tfn = database.get_fix_idx_filename(result[0])
-                    if (re.search(file_filter, tfn) is None) != file_filter_mode:
+                    if (re.search(self.file_filter, tfn) is None) != self.file_filter_mode:
                         valid_results += 1
             search_time = time.perf_counter() - search_start
             print(f"Search time: {search_time:.4f}s")
-        elif search_mode == 1:
+        elif self.search_mode == 1:
             # Search face embedding
             search_start = time.perf_counter()
-            D, I = faces_index.search(features, k + offset + 2)
-            results = merge_faiss_results(D, I, database.get_idx_face)
+            D, I = self.faces_index.search(self.features, self.k + self.offset + 2)
+            self.results = merge_faiss_results(D, I, database.get_idx_face)
             search_time = time.perf_counter() - search_start
             print(f"Search time: {search_time:.4f}s")
-        elif search_mode == 2:
+        elif self.search_mode == 2:
             # Search CLIP features containing face embedding
             search_start = time.perf_counter()
-            _, D, I = faces_index.range_search(x=face_features, thresh=face_threshold)
+            _, D, I = self.faces_index.range_search(x=self.face_features, thresh=self.face_threshold)
             face_results = merge_faiss_results_1d_dict(D, I, database.get_idx_face)
-            _, D, I = index.range_search(x=features, thresh=clip_threshold)
+            _, D, I = self.index.range_search(x=self.features, thresh=self.clip_threshold)
             np.set_printoptions(threshold=np.inf)
-            results = merge_faiss_results_1d(D, I, database.get_idx, face_results)
+            self.results = merge_faiss_results_1d(D, I, database.get_idx, face_results)
             search_time = time.perf_counter() - search_start
             print(f"Search time: {search_time:.4f}s")
 
-        # Do display
+    def do_display(self):
         compensate = 0
         n_results = 0
         if n_results is not None:
-            n_results = len(results)
+            n_results = len(self.results)
         j = 0
         go_dir = 1
         tried_j = -1
         while j < n_results:
-            if j - compensate <= offset:
+            if j - compensate <= self.offset:
                 j += 1
                 continue
-            if j - compensate >= offset + k:
+            if j - compensate >= self.offset + self.k:
                 break
             j = min(max(j, 0), n_results - 1)
-            result = results[j]
-            if search_mode == 1 and result[1] < face_threshold:
+            result = self.results[j]
+            if self.search_mode == 1 and result[1] < self.face_threshold:
                 break
             fix_idx = None
             face_id = None
@@ -524,41 +546,41 @@ try:
                 fix_idx = result[0][0]
                 tfn = database.get_fix_idx_filename(fix_idx)
                 vector = database.get_fix_idx_vector(fix_idx)
-                if last_vector is not None and np.array_equal(vector, last_vector) and search_mode != -2 and tried_j != j:
+                if self.last_vector is not None and np.array_equal(vector, self.last_vector) and self.search_mode != -2 and tried_j != j:
                     tried_j = j
                     j, compensate = go(j, go_dir, compensate)
                     continue
-                last_vector = vector
+                self.last_vector = vector
                 output = f"{result[1]:.4f} {fix_idx} {face_id} {tfn}"
             else:
                 fix_idx = result[0]
                 tfn = database.get_fix_idx_filename(fix_idx)
                 vector = database.get_fix_idx_vector(fix_idx)
-                if last_vector is not None and np.array_equal(vector, last_vector) and search_mode != -2:
+                if self.last_vector is not None and np.array_equal(vector, self.last_vector) and self.search_mode != -2:
                     j, compensate = go(j, go_dir, compensate)
                     continue
-                last_vector = vector
+                self.last_vector = vector
                 output = f"{result[1]:.4f} {fix_idx} {tfn}"
-            if file_filter is not None:
-                if (re.search(file_filter, tfn) is None) == file_filter_mode:
+            if self.file_filter is not None:
+                if (re.search(self.file_filter, tfn) is None) == self.file_filter_mode:
                     j, compensate = go(j, go_dir, compensate)
                     continue
-            if skip_perfect and result[1] > 0.999999 and tried_j != j:
+            if self.skip_perfect and result[1] > 0.999999 and tried_j != j:
                     tried_j = j
                     j, compensate = go(j, go_dir, compensate)
                     continue
             tried_j = -1
             annotations = None
-            if show_faces or target_tag is not None:
+            if self.show_faces or self.target_tag is not None:
                 annotations = database.get_faces(database.i2b(fix_idx))
                 found_tag = False
                 for a_i, annotation in enumerate(annotations):
-                    annotation['tag'] = config.get_face_tag(annotation, face_threshold)
+                    annotation['tag'] = config.get_face_tag(annotation, self.face_threshold)
                     if face_id is not None and a_i == face_id and result[1] > 0.99999:
                         annotation['color'] = (0, 255, 255)
-                    if target_tag is not None and annotation['tag'] == target_tag:
+                    if self.target_tag is not None and annotation['tag'] == self.target_tag:
                         found_tag = True
-                if target_tag is not None and not found_tag:
+                if self.target_tag is not None and not found_tag:
                     j, compensate = go(j, go_dir, compensate)
                     continue
             try:
@@ -568,23 +590,23 @@ try:
                     continue
                 h, w, _ = image.shape
                 scale = 1.0
-                if max_res is not None:
+                if self.max_res is not None:
                     need_resize = False
-                    if w > max_res[0]:
-                        factor = float(max_res[0])/float(w)
-                        w = max_res[0]
+                    if w > self.max_res[0]:
+                        factor = float(self.max_res[0])/float(w)
+                        w = self.max_res[0]
                         h *= factor
                         need_resize = True
                         scale *= factor
-                    if h > max_res[1]:
-                        factor = float(max_res[1])/float(h)
-                        h = max_res[1]
+                    if h > self.max_res[1]:
+                        factor = float(self.max_res[1])/float(h)
+                        h = self.max_res[1]
                         w *= factor
                         need_resize = True
                         scale *= factor
                     if need_resize:
                         image = cv2.resize(image, (int(w + 0.5), int(h + 0.5)), interpolation=cv2.INTER_LANCZOS4)
-                if show_faces:
+                if self.show_faces:
                     pillow_image = Image.open(tfn)
                     exif_data = pillow_image._getexif()
                     exif_orientation = None
@@ -592,7 +614,7 @@ try:
                         exif_orientation = exif_data[orientation]
                     image = annotate_faces(annotations, image=image, scale=scale, face_id=face_id, orientation=exif_orientation, skip_landmarks=True)
                 cv2.imshow('Image', image)
-                if align_window:
+                if self.align_window:
                     cv2.moveWindow('Image', 0, 0)
                 key = ""
                 do_break = False
@@ -610,15 +632,15 @@ try:
                         break
                     elif key == ord('+'):
                         go_dir = 1
-                        if target_tag is not None:
+                        if self.target_tag is not None:
                             result[1] = 1.0
-                            config.add_tag(target_tag, fix_idx, face_id)
+                            config.add_tag(self.target_tag, fix_idx, face_id)
                         break
                     elif key == ord('-'):
                         go_dir = 1
-                        if target_tag is not None:
-                            result[1] = face_threshold + 0.00001
-                            config.del_tag(target_tag, fix_idx, face_id)
+                        if self.target_tag is not None:
+                            result[1] = self.face_threshold + 0.00001
+                            config.del_tag(self.target_tag, fix_idx, face_id)
                         break
                 if do_break:
                     break
@@ -627,7 +649,8 @@ try:
                 continue
             j = j + go_dir
         cv2.destroyAllWindows()
-except EOFError:
-    print("Goodbye.")
-except KeyboardInterrupt:
-    print("Interrupted.")
+
+
+if __name__ == '__main__':
+    search = Search()
+    search.run_cli()

--- a/query-index.py
+++ b/query-index.py
@@ -16,12 +16,6 @@ import config
 import database
 from faces import annotate as annotate_faces
 
-# Might not exist, but let's try
-try:
-    import readline
-except:
-    pass
-
 def go(j, go_dir, compensate):
     if go_dir == 0:
         return j + 1, compensate + 1
@@ -652,5 +646,12 @@ class Search:
 
 
 if __name__ == '__main__':
+
+    # Might not exist, but let's try
+    try:
+        import readline
+    except:
+        pass
+
     search = Search()
     search.run_cli()

--- a/query-index.py
+++ b/query-index.py
@@ -518,7 +518,7 @@ class Search:
         n_results = 0
         if n_results is not None:
             n_results = len(self.results)
-        j = last_j + 1
+        j = self.last_j + 1
         go_dir = 1
         tried_j = -1
         while j < n_results:
@@ -533,7 +533,7 @@ class Search:
             fix_idx = None
             face_id = None
             output = ""
-            last_j = j
+            self.last_j = j
             if type(result[0]) is tuple:
                 face_id = result[0][1]
                 fix_idx = result[0][0]


### PR DESCRIPTION
Modularizes `query-index.py` by using a class to store the code in a way that can be invoked from elsewhere, e.g., a (yet-to-be-written) alternative front-end. (as previously discussed)

N.B.: Importing as module would currently only be possible by using, e.g., `__import__("query-index")`, so perhaps please also change the file name(s)!

Regards, canvon