### PR TITLE
PyQt5 GUI improvements: Stand-alone image display, more refactoring

### DIFF
--- a/gui.py
+++ b/gui.py
@@ -224,7 +224,7 @@ class MainWindow(QMainWindow):
             self.appendSearchOutput("No results.")
             return
         #self.stdoutSearchOutput(search.do_display)
-        self.appendSearchOutput("Building results model...")
+        self.appendSearchOutput(f"Building results model for {n_results} results...")
         j = 0
         while j < n_results:
             result, j, _ = search.prepare_result(j)
@@ -233,7 +233,7 @@ class MainWindow(QMainWindow):
             elif result is None:
                 continue
             self.appendToSearchResultsModel(result)
-        self.appendSearchOutput("Built results model.")
+        self.appendSearchOutput(f"Built results model with {self.searchResultsModel.rowCount()} entries.")
 
     def createSearchResultsModel(self):
         model = QStandardItemModel(0, 4)

--- a/gui.py
+++ b/gui.py
@@ -288,6 +288,14 @@ class MainWindow(QMainWindow):
             self.appendToSearchResultsModel(result)
         self.appendSearchOutput(f"Built results model with {self.searchResultsModel.rowCount()} entries.")
 
+        # Already activate Images tab and load first image...
+        self.tabWidget.setCurrentWidget(self.imagesTabPage)
+        view = self.imagesTableView
+        nextIndex = view.model().index(0, 0)
+        if nextIndex.isValid():
+            view.selectionModel().setCurrentIndex(nextIndex, QItemSelectionModel.SelectCurrent)
+            self.searchResultsActivated(nextIndex)
+
     def createSearchResultsModel(self):
         model = QStandardItemModel(0, 4)
         model.setHorizontalHeaderLabels(["score", "fix_idx", "face_id", "filename"])

--- a/gui.py
+++ b/gui.py
@@ -278,7 +278,7 @@ class MainWindow(QMainWindow):
             self.appendSearchOutput(f"Error preparing image: {ex}")
             return
         # Convert prepared image to Qt/GUI.
-        qtImage = QImage(image.data, image.shape[1], image.shape[0], QImage.Format_RGB888).rgbSwapped()
+        qtImage = QImage(image.data, image.shape[1], image.shape[0], 3 * image.shape[1], QImage.Format_RGB888).rgbSwapped()
         self.imageLabel.setPixmap(QPixmap.fromImage(qtImage))
 
 

--- a/gui.py
+++ b/gui.py
@@ -128,11 +128,15 @@ class MainWindow(QMainWindow):
         # Search input box & go button
         inputHBox = QHBoxLayout()
 
+        self.searchInputLabel = QLabel("&Search")
+        self.searchInputLabel.setSizePolicy(QSizePolicy.Fixed, QSizePolicy.Fixed)
+
         self.searchInput = HistoryComboBox()
         self.searchInput.setEditable(True)
         # This fired too often, but we only want to search
         # when the user finally hits return...
         #self.searchInput.activated.connect(self.handleSearchInput)
+        self.searchInputLabel.setBuddy(self.searchInput)
 
         self.searchInputButton = QPushButton()
         #
@@ -146,6 +150,7 @@ class MainWindow(QMainWindow):
         self.searchInputButton.setSizePolicy(QSizePolicy.Fixed, QSizePolicy.Fixed)
         self.searchInputButton.clicked.connect(self.handleSearchInput)
 
+        inputHBox.addWidget(self.searchInputLabel)
         inputHBox.addWidget(self.searchInput)
         inputHBox.addWidget(self.searchInputButton)
 

--- a/gui.py
+++ b/gui.py
@@ -20,7 +20,7 @@ from PyQt5.QtWidgets import (
     qApp,
     QApplication, QMainWindow, QWidget,
     QSizePolicy,
-    QHBoxLayout, QVBoxLayout, QTabWidget,
+    QHBoxLayout, QVBoxLayout, QScrollBar, QTabWidget,
     QComboBox, QLabel, QPushButton, QTextEdit,
     QTableView,
 )
@@ -184,9 +184,17 @@ class MainWindow(QMainWindow):
     def searchInputPageChangeRequested(self, pageUp):
         w = self.tabWidget.currentWidget()
         if w is self.consoleTabPage:
-            # FIXME: Scroll console log.
-            #self.consoleTabPage.scroll()
-            pass
+            # Scroll console log.
+            out = self.searchOutput
+            height = out.viewport().height()
+            # This didn't work:
+            #out.scrollContentsBy(0, height * (-1 if pageUp else 1))
+            # This worked, but doesn't provide overlap:
+            #out.verticalScrollBar().triggerAction(QScrollBar.SliderPageStepSub if pageUp else QScrollBar.SliderPageStepAdd)
+            # So we end up with this:
+            # (It scrolls by half the viewport height.)
+            vbar = out.verticalScrollBar()
+            vbar.setValue(vbar.value() + height * (-1 if pageUp else 1) / 2)
         elif w is self.imagesTabPage:
             # Scroll in & activate search results.
             view = self.imagesTableView

--- a/gui.py
+++ b/gui.py
@@ -263,7 +263,12 @@ class MainWindow(QMainWindow):
 
     def clearSearchResultsModel(self):
         self.searchResultSelected = None
-        self.searchResultsModel.clear()
+        #
+        # Don't use clear(), as that will get rid of the header labels
+        # and column count, too...
+        #self.searchResultsModel.clear()
+        self.searchResultsModel.setRowCount(0)
+        #
         self.imageLabel.clear()
 
     def appendToSearchResultsModel(self, result):

--- a/gui.py
+++ b/gui.py
@@ -209,6 +209,7 @@ class MainWindow(QMainWindow):
         if storedText != inputText:
             self.searchInput.addItem(inputText)
         self.searchInput.clearEditText()
+        self.clearSearchResultsModel()
 
         iteration_done = self.stdoutSearchOutput(search.do_command)
         if iteration_done:
@@ -218,10 +219,14 @@ class MainWindow(QMainWindow):
             return
 
         self.stdoutSearchOutput(search.do_search)
+        n_results = 0 if search.results is None else len(search.results)
+        if not n_results > 0:
+            self.appendSearchOutput("No results.")
+            return
         #self.stdoutSearchOutput(search.do_display)
         self.appendSearchOutput("Building results model...")
         j = 0
-        while j is not None:
+        while j < n_results:
             result, j, _ = search.prepare_result(j)
             if j is None:
                 break
@@ -236,6 +241,10 @@ class MainWindow(QMainWindow):
         self.searchResultsModel = model
         self.imagesTableView.setModel(model)
         self.imagesTableView.horizontalHeader().setStretchLastSection(True)
+
+    def clearSearchResultsModel(self):
+        self.searchResultSelected = None
+        self.searchResultsModel.clear()
 
     def appendToSearchResultsModel(self, result):
         model = self.searchResultsModel

--- a/gui.py
+++ b/gui.py
@@ -215,7 +215,13 @@ class MainWindow(QMainWindow):
         self.stdoutSearchOutput(search.do_search)
         #self.stdoutSearchOutput(search.do_display)
         self.appendSearchOutput("Building results model...")
-        for result in search.results:
+        j = 0
+        while j is not None:
+            result, j, _ = search.prepare_result(j)
+            if j is None:
+                break
+            elif result is None:
+                continue
             self.appendToSearchResultsModel(result)
         self.appendSearchOutput("Built results model.")
 
@@ -227,10 +233,14 @@ class MainWindow(QMainWindow):
         self.imagesTableView.horizontalHeader().setStretchLastSection(True)
 
     def appendToSearchResultsModel(self, result):
-        search = self.search
-        if search.search_mode is query_index.SearchMode.FACE and result[1] < search.face_threshold:
-            return
-        # FIXME
+        model = self.searchResultsModel
+        model.appendRow([
+            QStandardItem(str(result.score)),
+            QStandardItem(str(result.fix_idx)),
+            QStandardItem(str(result.face_id)),
+            QStandardItem(str(result.tfn)),
+        ])
+
 
 if __name__ == '__main__':
     app = QApplication(sys.argv)

--- a/gui.py
+++ b/gui.py
@@ -103,6 +103,8 @@ class MainWindow(QMainWindow):
         imagesVBox = QVBoxLayout(self.imagesTabPage)
 
         self.imageLabel = QLabel()
+        self.imageLabel.setMaximumHeight(self.size().height() * 8 / 10)
+        self.imageLabel.setSizePolicy(QSizePolicy.Preferred, QSizePolicy.Maximum)
         self.imagesTableView = QTableView()
         self.imagesTableView.activated.connect(self.searchResultsActivated)
 

--- a/gui.py
+++ b/gui.py
@@ -114,6 +114,7 @@ class MainWindow(QMainWindow):
 
         self.imageLabel = QLabel()
         self.imagesTableView = QTableView()
+        self.imagesTableView.setEditTriggers(QTableView.NoEditTriggers)
         self.imagesTableView.activated.connect(self.searchResultsActivated)
 
         imagesVBox.addWidget(self.imageLabel)

--- a/gui.py
+++ b/gui.py
@@ -245,6 +245,7 @@ class MainWindow(QMainWindow):
     def clearSearchResultsModel(self):
         self.searchResultSelected = None
         self.searchResultsModel.clear()
+        self.imageLabel.clear()
 
     def appendToSearchResultsModel(self, result):
         model = self.searchResultsModel

--- a/query-index.py
+++ b/query-index.py
@@ -590,6 +590,78 @@ class Search:
             search_time = time.perf_counter() - search_start
             print(f"Search time: {search_time:.4f}s")
 
+    class Result:
+        def __init__(self, result_elem):
+            self.result_elem = result_elem
+
+            self.fix_idx = None
+            self.face_id = None
+            self.tfn = None
+            self.vector = None
+            self.annotations = None
+            self.has_face_id = False
+            pos, self.score = self.result_elem
+            if type(pos) is tuple:
+                self.has_face_id = True
+                self.face_id = pos[1]
+                self.fix_idx = pos[0]
+            else:
+                self.fix_idx = pos
+        def __len__(self):
+            return len(self.result_elem)
+        def __getitem__(self, key):
+            return self.result_elem[key]
+
+        def format_output(self):
+            return (
+                f"{self.score:.4f} {self.fix_idx}" +
+                (f" {self.face_id}" if self.has_face_id else "") +
+                f" {self.tfn}"
+            )
+
+    def prepare_result(self, j, go_dir=0, compensate=0):
+        """
+        Gets from current results index j to a tuple (Result, next j, compensate).
+        Next j being None means break from the loop.
+        Result being None means continue the loop, skipping the omitted result.
+        """
+        result = self.Result(self.results[j])
+        if self.search_mode is SearchMode.FACE and result.score < self.face_threshold:
+            return None, None, None
+        self.last_j = j
+        # Retrieve tfn, vector.
+        result.tfn = database.get_fix_idx_filename(result.fix_idx)
+        result.vector = database.get_fix_idx_vector(result.fix_idx)
+        if self.last_vector is not None and np.array_equal(result.vector, self.last_vector) and self.search_mode is not SearchMode.NONE_NOSKIP and (self.tried_j != j if result.has_face_id else True):
+            if result.has_face_id:
+                self.tried_j = j
+            j, compensate = go(j, go_dir, compensate)
+            return None, j, compensate
+        self.last_vector = result.vector
+        if self.file_filter is not None:
+            if (re.search(self.file_filter, result.tfn) is None) == self.file_filter_mode:
+                j, compensate = go(j, go_dir, compensate)
+                return None, j, compensate
+        if self.skip_perfect and (result.score > 0.999999 or config.has_tag(self.target_tag, result.fix_idx, result.face_id, self.cluster_mode)) and self.tried_j != j:
+                self.tried_j = j
+                j, compensate = go(j, go_dir, compensate)
+                return None, j, compensate
+        self.tried_j = -1
+        # Retrieve annotations.
+        if self.show_faces or self.target_tag is not None:
+            result.annotations = database.get_faces(database.i2b(result.fix_idx))
+            found_tag = False
+            for a_i, annotation in enumerate(result.annotations):
+                annotation['tag'] = config.get_face_tag(annotation, self.face_threshold, self.cluster_mode)
+                if result.face_id is not None and a_i == result.face_id and result.score > 0.99999:
+                    annotation['color'] = (0, 255, 255)
+                if self.target_tag is not None and (annotation['tag'] == self.target_tag or (self.cluster_mode and annotation['tag'] == "")):
+                    found_tag = True
+            if self.target_tag is not None and not found_tag:
+                j, compensate = go(j, go_dir, compensate)
+                return None, j, compensate
+        return result, j, compensate
+
     def do_display(self):
         compensate = 0
         n_results = 0
@@ -597,64 +669,20 @@ class Search:
             n_results = len(self.results)
         j = self.last_j + 1
         go_dir = 1
-        tried_j = -1
+        self.tried_j = -1
         while j < n_results:
             if j < 0:
                 j = 0
             if j - compensate >= self.offset + self.k:
                 break
             j = min(max(j, 0), n_results - 1)
-            result = self.results[j]
-            if self.search_mode is SearchMode.FACE and result[1] < self.face_threshold:
+            result, j, compensate = self.prepare_result(j, go_dir, compensate)
+            if j is None:
                 break
-            fix_idx = None
-            face_id = None
-            output = ""
-            self.last_j = j
-            if type(result[0]) is tuple:
-                face_id = result[0][1]
-                fix_idx = result[0][0]
-                tfn = database.get_fix_idx_filename(fix_idx)
-                vector = database.get_fix_idx_vector(fix_idx)
-                if self.last_vector is not None and np.array_equal(vector, self.last_vector) and self.search_mode is not SearchMode.NONE_NOSKIP and tried_j != j:
-                    tried_j = j
-                    j, compensate = go(j, go_dir, compensate)
-                    continue
-                self.last_vector = vector
-                output = f"{result[1]:.4f} {fix_idx} {face_id} {tfn}"
-            else:
-                fix_idx = result[0]
-                tfn = database.get_fix_idx_filename(fix_idx)
-                vector = database.get_fix_idx_vector(fix_idx)
-                if self.last_vector is not None and np.array_equal(vector, self.last_vector) and self.search_mode is not SearchMode.NONE_NOSKIP:
-                    j, compensate = go(j, go_dir, compensate)
-                    continue
-                self.last_vector = vector
-                output = f"{result[1]:.4f} {fix_idx} {tfn}"
-            if self.file_filter is not None:
-                if (re.search(self.file_filter, tfn) is None) == self.file_filter_mode:
-                    j, compensate = go(j, go_dir, compensate)
-                    continue
-            if self.skip_perfect and (result[1] > 0.999999 or config.has_tag(self.target_tag, fix_idx, face_id, self.cluster_mode)) and tried_j != j:
-                    tried_j = j
-                    j, compensate = go(j, go_dir, compensate)
-                    continue
-            tried_j = -1
-            annotations = None
-            if self.show_faces or self.target_tag is not None:
-                annotations = database.get_faces(database.i2b(fix_idx))
-                found_tag = False
-                for a_i, annotation in enumerate(annotations):
-                    annotation['tag'] = config.get_face_tag(annotation, self.face_threshold, self.cluster_mode)
-                    if face_id is not None and a_i == face_id and result[1] > 0.99999:
-                        annotation['color'] = (0, 255, 255)
-                    if self.target_tag is not None and (annotation['tag'] == self.target_tag or (self.cluster_mode and annotation['tag'] == "")):
-                        found_tag = True
-                if self.target_tag is not None and not found_tag:
-                    j, compensate = go(j, go_dir, compensate)
-                    continue
+            elif result is None:
+                continue
             try:
-                image = cv2.imread(tfn, cv2.IMREAD_COLOR)
+                image = cv2.imread(result.tfn, cv2.IMREAD_COLOR)
                 if image is None or image.shape[0] < 2:
                     j, compensate = go(j, go_dir, compensate)
                     continue
@@ -677,18 +705,18 @@ class Search:
                     if need_resize:
                         image = cv2.resize(image, (int(w + 0.5), int(h + 0.5)), interpolation=cv2.INTER_LANCZOS4)
                 if self.show_faces:
-                    pillow_image = Image.open(tfn)
+                    pillow_image = Image.open(result.tfn)
                     exif_data = pillow_image._getexif()
                     exif_orientation = None
                     if exif_data is not None and orientation in exif_data:
                         exif_orientation = exif_data[orientation]
-                    image = annotate_faces(annotations, image=image, scale=scale, face_id=face_id, orientation=exif_orientation, skip_landmarks=True)
+                    image = annotate_faces(result.annotations, image=image, scale=scale, face_id=result.face_id, orientation=exif_orientation, skip_landmarks=True)
                 cv2.imshow('Image', image)
                 if self.align_window:
                     cv2.moveWindow('Image', 0, 0)
                 key = ""
                 do_break = False
-                print(output)
+                print(result.format_output())
                 while key != ord(" "):
                     key = cv2.waitKey(0) & 0xff
                     if key == ord('q'):
@@ -703,14 +731,14 @@ class Search:
                     elif key == ord('+'):
                         go_dir = 1
                         if self.target_tag is not None:
-                            result[1] = 1.0
-                            config.add_tag(self.target_tag, fix_idx, face_id, self.cluster_mode)
+                            result.result_elem[1] = 1.0
+                            config.add_tag(self.target_tag, result.fix_idx, result.face_id, self.cluster_mode)
                         break
                     elif key == ord('-'):
                         go_dir = 1
                         if self.target_tag is not None:
-                            result[1] = self.face_threshold + 0.00001
-                            config.del_tag(self.target_tag, fix_idx, face_id, self.cluster_mode)
+                            result.result_elem[1] = self.face_threshold + 0.00001
+                            config.del_tag(self.target_tag, result.fix_idx, result.face_id, self.cluster_mode)
                         break
                 if do_break:
                     break

--- a/query-index.py
+++ b/query-index.py
@@ -662,23 +662,25 @@ class Search:
                 return None, j, compensate
         return result, j, compensate
 
-    def prepare_image(self, result):
+    def prepare_image(self, result, max_res=None):
+        if max_res is None:
+            max_res = self.max_res
         image = cv2.imread(result.tfn, cv2.IMREAD_COLOR)
         if image is None or image.shape[0] < 2:
             return None
         h, w, _ = image.shape
         scale = 1.0
-        if self.max_res is not None:
+        if max_res is not None:
             need_resize = False
-            if w > self.max_res[0]:
-                factor = float(self.max_res[0])/float(w)
-                w = self.max_res[0]
+            if w > max_res[0]:
+                factor = float(max_res[0])/float(w)
+                w = max_res[0]
                 h *= factor
                 need_resize = True
                 scale *= factor
-            if h > self.max_res[1]:
-                factor = float(self.max_res[1])/float(h)
-                h = self.max_res[1]
+            if h > max_res[1]:
+                factor = float(max_res[1])/float(h)
+                h = max_res[1]
                 w *= factor
                 need_resize = True
                 scale *= factor

--- a/query-index.py
+++ b/query-index.py
@@ -714,7 +714,8 @@ class Search:
                         break
                 if do_break:
                     break
-            except:
+            except Exception as ex:
+                print(f"Error displaying result image {j+1}/{n_results}: {ex}")
                 j, compensate = go(j, go_dir, compensate)
                 continue
             j = j + go_dir


### PR DESCRIPTION
Hi,

the PyQt5 GUI alternative front-end can now display the search result images
within the GUI itself, that is, it doesn't use query-index's opencv window(s) anymore.
(It's still used for preparing the images data, though.)

Also, the search results are now available to the user as a table to scroll through
and/or use usual copy & paste shortcuts on.

This factors out code from query-index for alternative front-end use, again;
this time, it's do_display(), from which prepare_result() and prepare_image()
were extracted. It also adds a small class Search.Results, which wraps
a conventional search results entry, and helps to pass state around.
(e.g., out of prepare_result(), or into prepare_image().)

Hope these changes are ok and that query-index will still be fully working
with them applied; cursory manual testing looks good, though.

Regards, canvon